### PR TITLE
fix(riklet): network tap creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +296,16 @@ name = "chunked_transfer"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -456,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc64"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
+
+[[package]]
 name = "cri"
 version = "0.1.0"
 dependencies = [
@@ -549,6 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -571,6 +632,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -681,6 +761,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "devices"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "derive_more",
+ "dumbo",
+ "event-manager",
+ "io_uring",
+ "libc",
+ "logger",
+ "mmds",
+ "net_gen",
+ "rate_limiter",
+ "serde",
+ "snapshot",
+ "thiserror",
+ "timerfd",
+ "utils",
+ "versionize",
+ "versionize_derive",
+ "virtio_gen",
+ "vm-memory 0.3.0",
+ "vm-superio",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +862,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "dumbo"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "bitflags",
+ "derive_more",
+ "logger",
+ "micro_http",
+ "utils",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-manager"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbb5f730c95a458654dee0afb13f1ebb4fc3d7b772789d5f30713ec68fed75d"
+dependencies = [
+ "libc",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +974,7 @@ dependencies = [
 [[package]]
 name = "firepilot"
 version = "0.1.0"
-source = "git+https://github.com/polyxia-org/firepilot.git?branch=main#1c0c89a522296d15d82f38c5f93c05c319ecd392"
+source = "git+https://github.com/rik-org/firepilot.git?tag=v0.2.0#33e58e9ea6aade79055878f953d96858070bb39f"
 dependencies = [
  "hyper",
  "hyperlocal",
@@ -1030,6 +1164,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1272,6 +1416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1441,17 @@ checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "io_uring"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "derive_more",
+ "libc",
+ "utils",
+ "vm-memory 0.3.0",
 ]
 
 [[package]]
@@ -1439,6 +1603,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "logger"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "utils",
+ "vm-superio",
+]
+
+[[package]]
 name = "lz4"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "micro_http"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/micro-http?rev=4b18a04#4b18a043e997da5b5f679e3defc279fec908753e"
+dependencies = [
+ "libc",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1725,27 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "mmds"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "aes-gcm",
+ "base64 0.13.1",
+ "bincode",
+ "derive_more",
+ "dumbo",
+ "logger",
+ "micro_http",
+ "serde",
+ "serde_json",
+ "snapshot",
+ "thiserror",
+ "utils",
+ "versionize",
+ "versionize_derive",
 ]
 
 [[package]]
@@ -1571,6 +1780,77 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "net_gen"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5cf0b54effda4b91615c40ff0fd12d0d4c9a6e0f5116874f03941792ff535a"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea993e32c77d87f01236c38f572ecb6c311d592e56a06262a007fd2a6e31253c"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26305d12193227ef7b8227e7d61ae4eaf174607f79bd8eeceff07aacaefde497"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
 ]
 
 [[package]]
@@ -1706,6 +1986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +2053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +2089,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pathdiff"
@@ -1900,10 +2201,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -2103,6 +2428,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rate_limiter"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "logger",
+ "snapshot",
+ "timerfd",
+ "utils",
+ "versionize",
+ "versionize_derive",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2582,7 @@ dependencies = [
  "curl",
  "daemonize",
  "derive_more",
+ "devices",
  "firepilot",
  "futures-util",
  "gethostname",
@@ -2251,11 +2590,16 @@ dependencies = [
  "iptables",
  "libc",
  "lz4",
+ "netlink-packet-route",
  "nix 0.21.0",
  "node_metrics",
  "oci",
+ "pretty_assertions",
  "prost",
  "proto",
+ "rand",
+ "rate_limiter",
+ "rtnetlink",
  "serde",
  "serde_json",
  "shared",
@@ -2270,6 +2614,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-timing",
  "url",
+ "utils",
  "uuid 0.8.2",
 ]
 
@@ -2314,6 +2659,24 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-ident",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7d42da676fdf7e470e2502717587dd1089d8b48d9d1b846dcc3c01072858cb"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.26.2",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2579,6 +2942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "snapshot"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "libc",
+ "thiserror",
+ "versionize",
+ "versionize_derive",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2979,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2736,6 +3116,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "timerfd"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0664936efa25f2bbe03ca25b62c50f5f492abec07e59d6dcf45131014b33483f"
+dependencies = [
+ "rustix",
 ]
 
 [[package]]
@@ -3095,6 +3484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,6 +3509,21 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "derive_more",
+ "libc",
+ "net_gen",
+ "serde",
+ "thiserror",
+ "versionize",
+ "versionize_derive",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -3155,6 +3569,75 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versionize"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"
+dependencies = [
+ "bincode",
+ "crc64",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+ "versionize_derive",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "versionize_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140aa9fd298f667ea50fa1cb0d8530076924079285c623b18b8f8a1c28386b4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "virtio_gen"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+
+[[package]]
+name = "vm-memory"
+version = "0.3.0"
+source = "git+https://github.com/firecracker-microvm/firecracker.git?tag=v1.3.1#94752a7d79993d0db565c19b1469ae45922a8668"
+dependencies = [
+ "libc",
+ "utils",
+ "vm-memory 0.10.0",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "vm-superio"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de3dc0146d78558327419fac388850fc6cbf197e924c4659a4863db20b5af64"
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd64fe09d8e880e600c324e7d664760a17f56e9672b7495a86381b49e4f72f46"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -3403,3 +3886,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/riklet/src/iptables/mod.rs
+++ b/riklet/src/iptables/mod.rs
@@ -9,7 +9,7 @@ use iptables::IPTables as LibIptables;
 use std::convert::TryFrom;
 use std::fmt::Display;
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, trace};
 
 /// A wrapper around original iptables crates in order to better match
 /// rust usages. You can use this crate directly or use the wrapper
@@ -129,6 +129,7 @@ impl Drop for Iptables {
         if self.cleanup {
             let rules = self.rules.clone();
             for rule in rules.iter() {
+                trace!("Drop iptables rule {}", rule);
                 self.delete(rule).unwrap_or_else(|e| {
                     error!("Could not delete rule '{:?}', reason: {}", rule, e);
                 });

--- a/riklet/src/iptables/platform_linux.rs
+++ b/riklet/src/iptables/platform_linux.rs
@@ -1,3 +1,5 @@
+use tracing::{error, info, trace};
+
 use crate::iptables::rule::Rule;
 use crate::iptables::Result;
 use crate::iptables::{Iptables, IptablesError, MutateIptables};
@@ -20,10 +22,13 @@ impl MutateIptables for Iptables {
     /// assert!(result.is_ok());
     /// ```
     fn create(&mut self, rule: &Rule) -> Result<()> {
+        trace!("Tries to create iptables rule {}", rule);
         self.validate_combo_table_chain(rule.table.clone(), rule.chain.clone())?;
         if self.exists(rule)? {
+            trace!("Could not create rule {}", rule);
             return Err(IptablesError::AlreadyExist(rule.clone()));
         }
+
         self.inner
             .append(&rule.table.to_string(), &rule.chain.to_string(), &rule.rule)
             .map_err(|e| IptablesError::LoadFailed(e.to_string()))

--- a/riklet/src/network/net.rs
+++ b/riklet/src/network/net.rs
@@ -1,11 +1,13 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use crate::network::tap;
+use crate::network::tap::{self, open_tap_shell};
 use devices::virtio::Net as VirtioNet;
 use futures_util::TryStreamExt;
 use rtnetlink::new_connection;
 
-use tracing::debug;
+use tracing::{debug, error};
+
+use super::tap::close_tap_shell;
 
 type Result<T> = std::result::Result<T, NetworkInterfaceError>;
 
@@ -73,10 +75,12 @@ pub enum NetworkInterfaceError {
     IpAllocation(#[from] rtnetlink::Error),
     #[error("Interface name is invalid, expected to be less than 15 characters")]
     InvalidInterfaceName,
+    #[error("Failed to create TAP: {0}")]
+    ManageTap(String),
 }
 
 pub enum NetworkInterface {
-    TapInterface(VirtioNet),
+    TapInterface(String),
 }
 
 /// An instance of a network implementation, it can be either a tap interface or a just a veth
@@ -106,7 +110,8 @@ impl Net {
     /// interface depending on the input configuration
     pub async fn new_with_tap(config: NetworkInterfaceConfig) -> Result<Self> {
         debug!("New net tap interface with name: {}", config.iface_name);
-        let interface = NetworkInterface::TapInterface(tap::open_tap(&config)?);
+        let tap = open_tap_shell(&config)?;
+        let interface = NetworkInterface::TapInterface(tap);
         let net = Net {
             id: config.id.clone(),
             interface,
@@ -122,11 +127,7 @@ impl Net {
         let (connection, handle, _) = new_connection().map_err(NetworkInterfaceError::IpSocket)?;
         tokio::spawn(connection);
 
-        let iface = match self.interface {
-            NetworkInterface::TapInterface(ref iface) => iface.iface_name(),
-        };
-
-        let mut links = handle.link().get().match_name(iface.to_string()).execute();
+        let mut links = handle.link().get().match_name(self.iface_name()).execute();
 
         if let Some(link) = links
             .try_next()
@@ -143,15 +144,17 @@ impl Net {
 
         Ok(())
     }
-}
 
+    pub fn iface_name(&self) -> String {
+        match self.interface {
+            NetworkInterface::TapInterface(ref iface) => iface.clone(),
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use netlink_packet_route::{
-        constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
-        link::nlas::Nla,
-    };
+    use netlink_packet_route::link::nlas::Nla;
     use pretty_assertions::assert_eq;
 
     #[tokio::test]
@@ -162,12 +165,7 @@ mod tests {
             ipv4_addr: Ipv4Addr::new(172, 0, 0, 17),
         };
         let net = Net::new_with_tap(config).await.unwrap();
-        match net.interface {
-            NetworkInterface::TapInterface(ref iface) => {
-                assert_eq!(iface.iface_name(), "rust0nettest")
-            }
-            _ => panic!("Wrong interface type"),
-        }
+        assert_eq!(net.iface_name(), "rust0nettest");
     }
 
     #[tokio::test]
@@ -181,11 +179,9 @@ mod tests {
         let _net = Net::new_with_tap(config.clone()).await.unwrap();
         let net = Net::new_with_tap(config).await;
         assert!(net.is_err());
-        assert!(net
-            .err()
-            .unwrap()
-            .to_string()
-            .contains("Invalid TUN/TAP Backend provided by rust1nettest"));
+        let error = net.err().unwrap().to_string();
+        let expected_error = "Failed to create TAP: Tap creation failed, code 1, stderr: ioctl(TUNSETIFF): Device or resource busy\n";
+        assert_eq!(error, expected_error);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes # <!-- Issue # here -->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

Few things are included in this PR:

- Globally needed iptables rules are now part of the bootstrap
- Make more verbose `iptables` and `net` by using `trace!()` (can be seen through `RUST_LOG=riklet=trace`)
- Correct the usage of tap which were deleted too early (because out of scope so drop trait was triggered)
- Disabled `iptables` clean policy as it was triggered too early
- Remove `lz4` decompression 

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code is documented
- [ ] I provided unitary tests or procedure to test my code
- [ ] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->