### PR TITLE
feat(tooling): add command to run firecracker with custom rootfs / kernel

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,8 @@ This directory contains a few scripts that can be used to help our CI and our de
 There is a single entrypoint for all scripts which is `tool.sh`, you can run `./scripts/tool.sh --help` to
 learn about available commands.
 
+Those commands have been tested on `Debian 11`, there is no official support for other distributions.
+
 ## Available commands
 
 ### `mkkernel`
@@ -15,3 +17,15 @@ available at `scripts/vmlinux.bin`
 
 Creates a new rootfs based on `ubuntu:22.04` image with a few initial packages. It weight 150 MB, it's large,
 but the aime of this rootfs isn't to be small, but to be a base system that can be used for testing purposes.
+
+### `run-firecracker`
+
+**You need to have sudo on your machine in order to run**
+
+Based on images created by `mkkernel` and `mkrootfs`, it creates a new VM with Firecracker and runs it.
+
+It starts with few specifications:
+
+- Current terminal is binded to the VM's TTY
+- Network is configured through bootargs, host ip: 172.12.0.254, guest ip: 172.12.0.253
+- If you are runing the rootfs from `mkrootfs`, you should be able to `curl 172.12.0.253` and have a response

--- a/scripts/tool.sh
+++ b/scripts/tool.sh
@@ -14,6 +14,7 @@ sub_default() {
   echo "Commands:"
   echo "    mkkernel                    Build a kernel that can be used in firecracker"
   echo "    mkrootfs                    Create a rootfs with sample services and stuff"
+  echo "    run-firecracker             Run firecracker with kernel and rootfs built from this script"
   echo ""
   print_generic_options
 }
@@ -50,7 +51,7 @@ sub_mkkernel() {
 # Example: `./scripts/tool.sh mkrootfs`
 sub_mkrootfs() {
     # Size of the rootfs in MB
-    local size="200"
+    local size="250"
     local origin_image="ubuntu:22.04"
     local rootfs_dir_host=/tmp/firecracker/
     local rootfs_dir_guest=/rootfs
@@ -79,7 +80,7 @@ sub_mkrootfs() {
         -v "${rootfs_dir_host}:/${rootfs_dir_guest}" ${origin_image} \
         bash -s <<'EOF'
 packages="udev systemd-sysv iproute2 nginx"
-dirs="bin etc home lib lib64 opt root sbin usr"
+dirs="bin etc home lib lib64 opt root sbin usr var/lib/nginx"
 
 echo "Mount rootfs on the system"
 mount ${MNT_DIR}/rootfs.ext4 /rootfs
@@ -104,13 +105,121 @@ passwd -d root
 echo "Copy rootfs into the mounted volume"
 for d in $dirs; do tar c "/$d" | tar x -C /rootfs; done
 
-for d in dev proc run sys var; do mkdir /rootfs/${d}; done
+for d in dev proc run sys var/log/nginx; do mkdir -p /rootfs/${d}; done
 umount /rootfs
 EOF
 
     info "Move built rootfs into ${rootfs_output}"
     mv ${rootfs_dir_host}/rootfs.ext4 ${rootfs_output}
     info "DONE"
+}
+
+# Runs a firecracker VM based on rootfs and kernel available in ./scripts
+# 
+# Note: You need to have sudo installed on your machine to run this command, as it needs to create
+# a tap interface.
+#
+# Ref: https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
+sub_run-firecracker() {
+    set -m
+    local kernel="${PWD}/scripts/vmlinux"
+    local rootfs="${PWD}/scripts/rootfs.ext4"
+    local logs="${PWD}/scripts/firecracker.log"
+
+    local api_socket="/tmp/rik-api.socket"
+    # Network format:
+    #  ip=<ip>::<gateway>:<netmask>:<hostname>:<device>:<autoconf>
+    local boot_args="console=ttyS0 reboot=k panic=1 pci=off ip=172.12.0.253::172.12.0.254:255.255.255.252::eth0:off"
+
+    for cmd in "firecracker sudo"; do
+        check_prerequisite $cmd
+    done
+
+    if [ -S $api_socket ]; then
+        info "A previous firecracker instance is running, do you want to override it ?"
+        get_user_confirmation || exit 1
+        sudo rm -f $api_socket
+    fi
+
+    if [ ! -f $kernel ]; then
+        info "Kernel not found, please build it first"
+        exit 1
+    fi
+
+    if [ ! -f $rootfs ]; then
+        info "RootFS not found, please build it first"
+        exit 1
+    fi
+
+    if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+        info "KVM is available"
+    else
+        info "KVM is not available, please enable it in your system (are you root?)"
+        exit 1
+    fi
+
+    info "Run firecracker with kernel and rootfs"
+    sudo firecracker --api-sock $api_socket &
+    
+    info "Configure logger..."
+    echo "" > ${logs}
+    sudo curl -X PUT -f --unix-socket "${api_socket}" \
+    --data "{
+        \"log_path\": \"${logs}\",
+        \"level\": \"Debug\",
+        \"show_level\": true,
+        \"show_log_origin\": true
+    }" \
+    "http://localhost/logger"
+
+    info "Configure kernel..."
+    sudo curl -X PUT -f --unix-socket "${api_socket}" \
+    --data "{
+        \"kernel_image_path\": \"${kernel}\",
+        \"boot_args\": \"${boot_args}\"
+    }" \
+    "http://localhost/boot-source"
+
+    info "Configure rootfs..."
+    sudo curl -X PUT -f --unix-socket "${api_socket}" \
+    --data "{
+        \"drive_id\": \"rootfs\",
+        \"path_on_host\": \"${rootfs}\",
+        \"is_root_device\": true,
+        \"is_read_only\": false
+    }" \
+    "http://localhost/drives/rootfs"
+
+    info "Configure network..."
+    sudo curl -f --unix-socket "${api_socket}" -i \
+    -X PUT 'http://localhost/network-interfaces/eth0' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "iface_id": "eth0",
+        "guest_mac": "AA:FC:00:00:00:01",
+        "host_dev_name": "rik-tap0"
+        }'
+
+    info "Give IP 172.12.0.254 to host TAP interface"
+    sudo ip addr add 172.12.0.254/30 dev rik-tap0
+    sudo ip link set rik-tap0 up
+
+    # API requests are handled asynchronously, it is important the microVM has been
+    # started before we attempt to SSH into it.
+    sleep 0.015s
+
+    info "Starting VM"
+    sudo curl -X PUT -f --unix-socket "${api_socket}" \
+    --data "{
+        \"action_type\": \"InstanceStart\"
+    }" \
+    "http://localhost/actions" &
+
+    info "Firecracker is running"
+    fg %1
+
+
 }
 
 parse_and_run_command $@


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes # <!-- Issue # here -->

## 📑 Description

Add a command on `scripts/tool.sh`: `run-firecracker`, it will run a firecracker microVM based on the rootfs and kernel available in `scripts` directory. It will also create a tap and allocate a static IP to the VM, with the rootfs given by `mkrootfs`, you should be able to `curl ${microvm_ip}` without problem.

It also fix nginx service as it couldn't boot properly

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code is documented
- [ ] I provided unitary tests or procedure to test my code
- [ ] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->