### PR TITLE
docs: background color to white for mermaid schema

### DIFF
--- a/docs/src/workloads/index.md
+++ b/docs/src/workloads/index.md
@@ -7,7 +7,7 @@ instance immediately, but it will be used as a definition to deploy an instance.
 
 The implementation only support JSON format, but the API is designed to be
 extensible to support other formats in the future. In case you expect to have a
-specific format, please 
+specific format, please
 [open an issue](https://github.com/rik-org/rik/issues/new/choose)
 to discuss it.
 
@@ -39,15 +39,15 @@ sequenceDiagram
     participant Secondary as RIK Secondary Node
     Bob-->>Primary: Request new instance <br/>of a workload
     note over Primary: Status: PENDING
-    Primary-->>Scheduler: Request Schedule 
+    Primary-->>Scheduler: Request Schedule
     note over Scheduler: Status: PENDING
     Scheduler-->>Secondary: Determine appropriate node and<br/> order scheduler
     note over Secondary: Status: CREATING
     Secondary-->>Secondary: Download and run <br/> necessary components
     note over Secondary: Status: RUNNING
-    Secondary-->>Scheduler: Return instance running OK 
-    Scheduler-->>Primary: Return instance running OK 
-    Primary-->>Bob: Return instance running OK 
+    Secondary-->>Scheduler: Return instance running OK
+    Scheduler-->>Primary: Return instance running OK
+    Primary-->>Bob: Return instance running OK
 
 ```
 
@@ -57,5 +57,13 @@ sequenceDiagram
 {{#include schema-v1.json}}
 ```
 
-[^1]: This workload will probably be renamed in the future, as it is not
-      strictly related to functions.
+[^1]:
+    This workload will probably be renamed in the future, as it is not
+    strictly related to functions.
+
+<style>
+    .mermaid {
+        background-color: #fff;
+        border-radius: 10px;
+    }
+</style>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/78204354/234887271-36a12272-bce8-4d00-89cc-3992ef57b133.png)
preview of the changes

## 📑 fix background color to white for mermaid schema in workloads

currently the text between the --> is grey on black and hard to see. 

https://rik-org.github.io/rik/workloads/index.html


## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [ ] My code is documented
- [ ] I provided unitary tests or procedure to test my code
- [X] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

not sure about the <style> tag in the markdown 