### PR TITLE
fix(ci): downgrade base docker image to build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 35
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   lint:
     name: Validating code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1
@@ -30,8 +30,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
+          # target: x86_64-unknown-linux-gnu
           override: true
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
@@ -50,16 +50,20 @@ jobs:
           command: check
 
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: libc
+        run: |
+          sudo apt update 
+          sudo apt install -y libc6 libssl-dev protobuf-compiler
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
+          # target: x86_64-unknown-linux-gnu
           override: true
       - uses: Swatinem/rust-cache@v2
       # Some tests must be running with root user, to do that we force tests to run with sudo
@@ -77,7 +81,7 @@ jobs:
     needs:
       - lint
       - tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,8 @@ dependencies = [
 name = "definition"
 version = "0.1.0"
 dependencies = [
+ "libc",
+ "openssl",
  "serde",
  "serde_json",
  "tracing",
@@ -2098,9 +2100,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.48"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -2129,14 +2131,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.83"
+name = "openssl-src"
+version = "111.25.3+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
 dependencies = [
- "autocfg",
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/definition/Cargo.toml
+++ b/crates/definition/Cargo.toml
@@ -11,3 +11,5 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 url = { version = "2.3.1", features = ["serde"] }
 tracing = { workspace = true }
+openssl = { version = "0.10.52", features = ["vendored"] }
+libc = "0.2.31"


### PR DESCRIPTION
We recently discovered that the usage of ubuntu 22.04 requires to have a recent version of glibc. That's the docker image used to build RIK which makes binaries unable to run on some systems. This commit downgrades base docker images to ubuntu 20.04 in order to have an older version of glibc, and so have a wider compatibility.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes # <!-- Issue # here -->

## 📑 Description

When taking binaries of RIK from release, run can fail if you don't have a very recent version of glibc. This PR downgrade used version of ubuntu in order to use a lower version of glibc. See commit for more info

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [ ] My pull request adheres to the code style of this project
- [ ] My code is documented
- [ ] I provided unitary tests or procedure to test my code
- [ ] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->