### PR TITLE
fix(riklet): microVM external network access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "default-net"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4898b43aed56499fad6b294d15b3e76a51df68079bf492e5daae38ca084e003"
+dependencies = [
+ "dlopen2",
+ "libc",
+ "memalloc",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows 0.32.0",
+]
+
+[[package]]
 name = "definition"
 version = "0.1.0"
 dependencies = [
@@ -914,6 +931,29 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b121caccfc363e4d9a4589528f3bef7c71b83c6ed01c8dc68cbeeb7fd29ec698"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a09ac8bb8c16a282264c379dffba707b9c998afc7506009137f3c6136888078"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1722,26 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
-dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1784,12 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "memalloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
 
 [[package]]
 name = "memchr"
@@ -2704,6 +2730,7 @@ dependencies = [
  "cri",
  "curl",
  "daemonize",
+ "default-net",
  "definition",
  "derive_more",
  "devices",
@@ -2713,7 +2740,6 @@ dependencies = [
  "ipnetwork",
  "iptables",
  "libc",
- "lz4",
  "netlink-packet-route",
  "nix 0.26.2",
  "node_metrics",
@@ -3185,6 +3211,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75182f12f490e953596550b65ee31bda7c8e043d9386174b353bda50838c3fd"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3983,17 +4030,30 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4012,12 +4072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4036,12 +4096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4052,9 +4112,21 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4064,9 +4136,21 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4079,6 +4163,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/docs/src/reference/riklet.md
+++ b/docs/src/reference/riklet.md
@@ -19,8 +19,8 @@ To run riklet with FAAS configuration.
 
 ```bash
 sudo riklet --kernel-path ${KERNEL_LOCATION} \
-            --ifnet ${IFACE} \
-            --ifnet-ip ${IFACE_IP} \
+            --iface ${IFACE} \
+            --iface-ip ${IFACE_IP} \
 ```
 
 > The firecracker binary location is determined by the following order:
@@ -33,7 +33,7 @@ Exemple:
 
 ```bash
 sudo riklet --kernel-path ./vmlinux.bin  \
-            --ifnet wlp2s0  \
-            --ifnet-ip 192.168.1.84  \
+            --iface wlp2s0  \
+            --iface-ip 192.168.1.84  \
             --script-path ./scripts/setup-host-tap.sh
 ```

--- a/riklet/Cargo.toml
+++ b/riklet/Cargo.toml
@@ -51,10 +51,10 @@ ipnetwork="0.20.0"
 iptables="0.5.0"
 url = { version = "2.3.1", features = ["serde"] }
 curl = "0.4.44"
-lz4 = "1.23.1"
 thiserror = "1.0.38"
 derive_more = "0.99.17"
 anyhow = "1.0.71"
+default-net = "0.14"
 
 # Instrumentation
 tracing = { workspace = true }

--- a/riklet/README.md
+++ b/riklet/README.md
@@ -54,8 +54,8 @@ To run riklet with FAAS configuration.
 
 ```bash
 sudo riklet --kernel-path ${KERNEL_LOCATION} \
-            --ifnet ${IFACE} \
-            --ifnet-ip ${IFACE_IP} \
+            --iface ${IFACE} \
+            --iface-ip ${IFACE_IP} \
 ```
 
 > The firecracker binary location is determined by the following order:
@@ -68,8 +68,8 @@ Exemple:
 
 ```bash
 sudo riklet --kernel-path ./vmlinux.bin  \
-            --ifnet wlp2s0  \
-            --ifnet-ip 192.168.1.84
+            --iface wlp2s0  \
+            --iface-ip 192.168.1.84
 ```
 
 You should see something like that :

--- a/riklet/src/cli/function_config.rs
+++ b/riklet/src/cli/function_config.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+use std::{net::Ipv4Addr, path::PathBuf};
+
+use crate::net_utils::{get_default_gateway, get_default_iface};
 
 use super::CliConfiguration;
 use clap::Parser;
@@ -6,14 +8,10 @@ use clap::Parser;
 #[derive(Debug, Clone)]
 pub struct FnConfiguration {
     pub kernel_location: PathBuf,
-}
-
-impl From<CliConfiguration> for FnConfiguration {
-    fn from(cli: CliConfiguration) -> Self {
-        FnConfiguration {
-            kernel_location: cli.kernel_path,
-        }
-    }
+    /// IP used to access the external network
+    pub gateway_ip: Ipv4Addr,
+    /// Network interface used to access the external network
+    pub iface: String,
 }
 
 impl FnConfiguration {
@@ -21,8 +19,22 @@ impl FnConfiguration {
         CliConfiguration::parse()
     }
 
-    pub fn load() -> Self {
+    pub fn load() -> Result<FnConfiguration, anyhow::Error> {
         let opts = FnConfiguration::get_cli_args();
-        FnConfiguration::from(opts)
+
+        let gateway_ip = match opts.iface_ip {
+            Some(ip) => ip,
+            None => get_default_gateway()?,
+        };
+        let iface = match opts.iface {
+            Some(iface) => iface,
+            None => get_default_iface()?,
+        };
+        Ok(FnConfiguration {
+            firecracker_location: opts.firecracker_path,
+            kernel_location: opts.kernel_path,
+            gateway_ip,
+            iface,
+        })
     }
 }

--- a/riklet/src/cli/function_config.rs
+++ b/riklet/src/cli/function_config.rs
@@ -31,7 +31,6 @@ impl FnConfiguration {
             None => get_default_iface()?,
         };
         Ok(FnConfiguration {
-            firecracker_location: opts.firecracker_path,
             kernel_location: opts.kernel_path,
             gateway_ip,
             iface,

--- a/riklet/src/cli/mod.rs
+++ b/riklet/src/cli/mod.rs
@@ -28,19 +28,15 @@ pub struct CliConfiguration {
         default_value = "vmlinux.bin"
     )]
     pub kernel_path: PathBuf,
-    /// DEPRECATED: Network interface that is used to connect to internet
-    ///
-    /// It was previously used to configure iptables, it is not the case anymore
-    #[arg(long, value_name = "IFNET", env = "IFNET", default_value = "eth0")]
-    pub ifnet: Option<String>,
-    /// DEPRECATED: IP of the network interface
-    ///
-    /// It was previously used to configure iptables, it is not the case anymore.
+    /// Override the default network interface detected by the software
+    #[arg(long, value_name = "IFACE", env = "IFACE", default_value = "eth0")]
+    pub iface: Option<String>,
+    /// Override the default IP gateway used by the software, it should match the IP given to ifnet
     #[arg(
         long,
-        value_name = "IFNET_IP",
-        env = "IFNET_IP",
+        value_name = "IFACE_IP",
+        env = "IFACE_IP",
         value_parser = value_parser!(Ipv4Addr)
     )]
-    pub ifnet_ip: Option<Ipv4Addr>,
+    pub iface_ip: Option<Ipv4Addr>,
 }

--- a/riklet/src/core.rs
+++ b/riklet/src/core.rs
@@ -1,5 +1,6 @@
 use crate::banner;
 use crate::cli::config::{Configuration, ConfigurationError};
+use crate::cli::function_config::FnConfiguration;
 use crate::emitters::metrics_emitter::MetricsEmitter;
 use crate::runtime::network::{GlobalRuntimeNetwork, NetworkError, RuntimeNetwork};
 use crate::runtime::{DynamicRuntimeManager, Runtime, RuntimeConfigurator, RuntimeError};
@@ -201,7 +202,10 @@ impl Riklet {
         });
         let stream = client.register(request).await.unwrap().into_inner();
 
-        let mut global_runtime_network = GlobalRuntimeNetwork::new()
+        let fn_configuration =
+            FnConfiguration::load().map_err(|e| RikletError::InvalidInput(e.to_string()))?;
+
+        let mut global_runtime_network = GlobalRuntimeNetwork::new(fn_configuration.gateway_ip)
             .map_err(|e| RikletError::NetworkError(NetworkError::IptablesError(e)))?;
         global_runtime_network
             .init()

--- a/riklet/src/core.rs
+++ b/riklet/src/core.rs
@@ -205,7 +205,7 @@ impl Riklet {
         let fn_configuration =
             FnConfiguration::load().map_err(|e| RikletError::InvalidInput(e.to_string()))?;
 
-        let mut global_runtime_network = GlobalRuntimeNetwork::new(fn_configuration.gateway_ip)
+        let mut global_runtime_network = GlobalRuntimeNetwork::new(fn_configuration.iface)
             .map_err(|e| RikletError::NetworkError(NetworkError::IptablesError(e)))?;
         global_runtime_network
             .init()

--- a/riklet/src/runtime/function_runtime.rs
+++ b/riklet/src/runtime/function_runtime.rs
@@ -241,7 +241,8 @@ impl RuntimeManager for FunctionRuntimeManager {
                 .map_err(RuntimeError::ParsingError)?;
 
         Ok(Box::new(FunctionRuntime {
-            function_config: FnConfiguration::load(),
+            function_config: FnConfiguration::load()
+                .map_err(|e| RuntimeError::Error(e.to_string()))?,
             file_path: self.create_fs(&workload_definition)?,
             network: FunctionRuntimeNetwork::new(&workload).map_err(RuntimeError::NetworkError)?,
             machine: None,

--- a/riklet/src/runtime/function_runtime.rs
+++ b/riklet/src/runtime/function_runtime.rs
@@ -240,11 +240,13 @@ impl RuntimeManager for FunctionRuntimeManager {
             serde_json::from_str(workload.definition.as_str())
                 .map_err(RuntimeError::ParsingError)?;
 
+        let fn_config = FnConfiguration::load().map_err(|e| RuntimeError::Error(e.to_string()))?;
+
         Ok(Box::new(FunctionRuntime {
-            function_config: FnConfiguration::load()
-                .map_err(|e| RuntimeError::Error(e.to_string()))?,
+            function_config: fn_config.clone(),
             file_path: self.create_fs(&workload_definition)?,
-            network: FunctionRuntimeNetwork::new(&workload).map_err(RuntimeError::NetworkError)?,
+            network: FunctionRuntimeNetwork::new(&workload, fn_config.iface)
+                .map_err(RuntimeError::NetworkError)?,
             machine: None,
             id: workload.instance_id,
         }))

--- a/riklet/src/runtime/network/function_network.rs
+++ b/riklet/src/runtime/network/function_network.rs
@@ -196,6 +196,8 @@ mod tests {
 
     use super::FunctionRuntimeNetwork;
 
+    const GATEWAY_MOCK: Ipv4Addr = Ipv4Addr::new(192, 168, 0, 1);
+
     fn open_tap_shell(iface_name: &str) -> Result<(), String> {
         let tap_output = Command::new("ip")
             .args(["tuntap", "add", iface_name, "mode", "tap"])
@@ -260,7 +262,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn apply_exposure_network_routing() {
-        let mut network = GlobalRuntimeNetwork::new().unwrap();
+        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK).unwrap();
         let result = network.init().await;
         assert!(result.is_ok());
 

--- a/riklet/src/runtime/network/mod.rs
+++ b/riklet/src/runtime/network/mod.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use shared::utils::ip_allocator::IpAllocator;
 use std::fmt::Debug;
-use std::net::Ipv4Addr;
 use std::sync::Mutex;
 use thiserror::Error;
 
@@ -58,13 +57,11 @@ pub struct GlobalRuntimeNetwork {
     iptables: Iptables,
 
     /// Name of the interface that will be used as the gateway for the network
-    gateway_iface: Ipv4Addr,
+    gateway_iface: String,
 }
 
 impl GlobalRuntimeNetwork {
-    pub fn new(
-        gateway_iface: Ipv4Addr,
-    ) -> std::result::Result<GlobalRuntimeNetwork, IptablesError> {
+    pub fn new(gateway_iface: String) -> std::result::Result<GlobalRuntimeNetwork, IptablesError> {
         Ok(GlobalRuntimeNetwork {
             iptables: Iptables::new(true)?,
             gateway_iface,
@@ -122,16 +119,8 @@ impl RuntimeNetwork for GlobalRuntimeNetwork {
             rule: format!("-o {} -j MASQUERADE", self.gateway_iface),
         };
 
-        let filter_conntrack = Rule {
-            chain: Chain::Forward,
-            table: Table::Filter,
-            rule: "-m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT".to_string(),
-        };
         self.iptables
             .create(&nat_masquerade)
-            .map_err(NetworkError::IptablesError)?;
-        self.iptables
-            .create(&filter_conntrack)
             .map_err(NetworkError::IptablesError)?;
         Ok(())
     }
@@ -151,12 +140,12 @@ mod tests {
     use crate::runtime::network::{GlobalRuntimeNetwork, RuntimeNetwork};
     use serial_test::serial;
 
-    const GATEWAY_MOCK: Ipv4Addr = Ipv4Addr::new(192, 168, 0, 1);
+    const GATEWAY_MOCK: &str = "eth0";
 
     #[tokio::test]
     #[serial]
     async fn test_network_init_ok() {
-        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK).unwrap();
+        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK.to_string()).unwrap();
         let result = network.init().await;
         assert!(result.is_ok());
         let result = network.destroy().await;
@@ -166,7 +155,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_network_init_drop() {
-        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK).unwrap();
+        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK.to_string()).unwrap();
         let result = network.init().await;
         assert!(result.is_ok());
 
@@ -213,19 +202,15 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_multiple_global_network_fails() {
-        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK).unwrap();
+        let mut network = GlobalRuntimeNetwork::new(GATEWAY_MOCK.to_string()).unwrap();
         let result = network.init().await;
         assert!(result.is_ok());
 
-        let mut network2 = GlobalRuntimeNetwork::new(GATEWAY_MOCK).unwrap();
+        let mut network2 = GlobalRuntimeNetwork::new(GATEWAY_MOCK.to_string()).unwrap();
         let result = network2.init().await;
         assert!(result.is_err());
 
         let result = network.destroy().await;
         assert!(result.is_ok());
-    }
-
-    fn test_to_string_gateway() {
-        assert_eq!(GATEWAY_MOCK.to_string(), "192.168.0.1".to_string());
     }
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #115 

## 📑 Description

- Remove deprecation of arguments `ifnet` and `ifnet_ip`
- Rename arguments `ifnet` and `ifnet_ip` to `iface` and `iface_ip`
- Add auto-detection of iface used to access external network, and the default gateway
- `ifnet` and `ifnet_ip` can supersed the auto-detection
- Creates few Iptables rules in order to allow forwarding of packets from microVM to external networks

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code is documented
- [x] I provided unitary tests or procedure to test my code
- [x] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->