### PR TITLE
chore(riklet): use firepilot binary autoload

### DIFF
--- a/docs/src/reference/riklet.md
+++ b/docs/src/reference/riklet.md
@@ -4,7 +4,7 @@
 
 ## Faas Configuration
 
-**Prerequisite**: You need firecracker in yout PATH.
+**Prerequisite**: You need firecracker in your PATH.
 
 Here is a list of **required** environment variables to run riklet:
 
@@ -14,7 +14,6 @@ Here is a list of **required** environment variables to run riklet:
 | `IFACE_IP`             | IP of the Network interface connected to the internet                                                                   | ""      |
 | `FIRECRACKER_LOCATION` | Path to the firecracker binary                                                                                          | ""      |
 | `KERNEL_LOCATION`      | Path to the kernel location                                                                                             | ""      |
-| `SCRIPT_LOCATION`      | Path to the [script](https://github.com/polyxia-org/rik/blob/main/scripts/setup-host-tap.sh) that create tap interface. | ""      |
 
 To run riklet with FAAS configuration.
 
@@ -22,7 +21,6 @@ To run riklet with FAAS configuration.
 sudo riklet --kernel-path ${KERNEL_LOCATION} \
             --ifnet ${IFACE} \
             --ifnet-ip ${IFACE_IP} \
-            --script-path ${SCRIPT_LOCATION}
 ```
 
 > The firecracker binary location is determined by the following order:

--- a/docs/src/reference/riklet.md
+++ b/docs/src/reference/riklet.md
@@ -6,7 +6,7 @@
 
 **Prerequisite**: You need firecracker in your PATH.
 
-Here is a list of **required** environment variables to run riklet:
+Here is a list of environment variables that can be used to configure run riklet:
 
 | Environment Variable   | Description                                                                                                             | Default |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/docs/src/reference/riklet.md
+++ b/docs/src/reference/riklet.md
@@ -1,0 +1,41 @@
+# Riklet
+
+[Rust in Kube (RIK)](https://github.com/dev-sys-do/rik) node agent
+
+## Faas Configuration
+
+**Prerequisite**: You need firecracker in yout PATH.
+
+Here is a list of **required** environment variables to run riklet:
+
+| Environment Variable   | Description                                                                                                             | Default |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| `IFACE`                | Network interface connected to the internet                                                                             | ""      |
+| `IFACE_IP`             | IP of the Network interface connected to the internet                                                                   | ""      |
+| `FIRECRACKER_LOCATION` | Path to the firecracker binary                                                                                          | ""      |
+| `KERNEL_LOCATION`      | Path to the kernel location                                                                                             | ""      |
+| `SCRIPT_LOCATION`      | Path to the [script](https://github.com/polyxia-org/rik/blob/main/scripts/setup-host-tap.sh) that create tap interface. | ""      |
+
+To run riklet with FAAS configuration.
+
+```bash
+sudo riklet --kernel-path ${KERNEL_LOCATION} \
+            --ifnet ${IFACE} \
+            --ifnet-ip ${IFACE_IP} \
+            --script-path ${SCRIPT_LOCATION}
+```
+
+> The firecracker binary location is determined by the following order:
+>
+> - **$FIRECRACKER_LOCATION** environment variable: direct path to the binary
+> - **$PATH** environment variable: search for the binary in the directories
+> - firecracker binary in the current working directory
+
+Exemple:
+
+```bash
+sudo riklet --kernel-path ./vmlinux.bin  \
+            --ifnet wlp2s0  \
+            --ifnet-ip 192.168.1.84  \
+            --script-path ./scripts/setup-host-tap.sh
+```

--- a/riklet/README.md
+++ b/riklet/README.md
@@ -39,7 +39,7 @@ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo run --bin riklet
 
 ### Faas Usage
 
-**Prerequisite**: You need firecracker in yout PATH.
+**Prerequisite**: You need firecracker in your PATH.
 
 Here is a list of **required** environment variables to run riklet:
 
@@ -49,7 +49,6 @@ Here is a list of **required** environment variables to run riklet:
 | `IFACE_IP`             | IP of the Network interface connected to the internet                                                                   | ""      |
 | `FIRECRACKER_LOCATION` | Path to the firecracker binary                                                                                          | ""      |
 | `KERNEL_LOCATION`      | Path to the kernel location                                                                                             | ""      |
-| `SCRIPT_LOCATION`      | Path to the [script](https://github.com/polyxia-org/rik/blob/main/scripts/setup-host-tap.sh) that create tap interface. | ""      |
 
 To run riklet with FAAS configuration.
 
@@ -57,7 +56,6 @@ To run riklet with FAAS configuration.
 sudo riklet --kernel-path ${KERNEL_LOCATION} \
             --ifnet ${IFACE} \
             --ifnet-ip ${IFACE_IP} \
-            --script-path ${SCRIPT_LOCATION}
 ```
 
 > The firecracker binary location is determined by the following order:
@@ -71,8 +69,7 @@ Exemple:
 ```bash
 sudo riklet --kernel-path ./vmlinux.bin  \
             --ifnet wlp2s0  \
-            --ifnet-ip 192.168.1.84  \
-            --script-path ./scripts/setup-host-tap.sh
+            --ifnet-ip 192.168.1.84
 ```
 
 You should see something like that :

--- a/riklet/README.md
+++ b/riklet/README.md
@@ -41,7 +41,7 @@ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo run --bin riklet
 
 **Prerequisite**: You need firecracker in your PATH.
 
-Here is a list of **required** environment variables to run riklet:
+Here is a list of environment variables that can be used to configure run riklet:
 
 | Environment Variable   | Description                                                                                                             | Default |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/riklet/README.md
+++ b/riklet/README.md
@@ -54,15 +54,25 @@ Here is a list of **required** environment variables to run riklet:
 To run riklet with FAAS configuration.
 
 ```bash
-sudo riklet --firecracker-path ${FIRECRACKER_LOCATION} \
-    --kernel-path ${KERNEL_LOCATION} --ifnet ${IFACE} \
-    --ifnet-ip ${IFACE_IP} --script-path ${SCRIPT_LOCATION}
+sudo riklet --kernel-path ${KERNEL_LOCATION} \
+            --ifnet ${IFACE} \
+            --ifnet-ip ${IFACE_IP} \
+            --script-path ${SCRIPT_LOCATION}
 ```
+
+> The firecracker binary location is determined by the following order:
+>
+> - **$FIRECRACKER_LOCATION** environment variable: direct path to the binary
+> - **$PATH** environment variable: search for the binary in the directories
+> - firecracker binary in the current working directory
 
 Exemple:
 
 ```bash
-sudo riklet --firecracker-path $(which firecracker) --kernel-path ./vmlinux.bin --ifnet wlp2s0 --ifnet-ip 192.168.1.84 --script-path ./scripts/setup-host-tap.sh
+sudo riklet --kernel-path ./vmlinux.bin  \
+            --ifnet wlp2s0  \
+            --ifnet-ip 192.168.1.84  \
+            --script-path ./scripts/setup-host-tap.sh
 ```
 
 You should see something like that :
@@ -74,7 +84,7 @@ You should see something like that :
         |    /  | | |    \ | |    |  __|  | |
         | |\ \ _| |_| |\  \| |____| |___  | |
         \_| \_|\___/\_| \_/\_____/\____/  \_/
-        
+
 [2021-07-03T15:04:09Z INFO  riklet::core] Riklet (v0.1.0) is ready to accept connections.
 ```
 

--- a/riklet/src/cli/function_config.rs
+++ b/riklet/src/cli/function_config.rs
@@ -5,14 +5,12 @@ use clap::Parser;
 
 #[derive(Debug, Clone)]
 pub struct FnConfiguration {
-    pub firecracker_location: PathBuf,
     pub kernel_location: PathBuf,
 }
 
 impl From<CliConfiguration> for FnConfiguration {
     fn from(cli: CliConfiguration) -> Self {
         FnConfiguration {
-            firecracker_location: cli.firecracker_path,
             kernel_location: cli.kernel_path,
         }
     }

--- a/riklet/src/cli/mod.rs
+++ b/riklet/src/cli/mod.rs
@@ -20,14 +20,6 @@ pub struct CliConfiguration {
     /// If set and there is a config file, values defined by the CLI will override values of the configuration file.
     #[arg(long)]
     pub override_config: bool,
-    /// Path to a firecracker binary on your system
-    #[arg(
-        long,
-        value_name = "FIRECRACKER_LOCATION",
-        env = "FIRECRACKER_LOCATION",
-        default_value = "firecracker"
-    )]
-    pub firecracker_path: PathBuf,
     /// Path to the linux kernel.
     #[arg(
         long,

--- a/riklet/src/runtime/function_runtime.rs
+++ b/riklet/src/runtime/function_runtime.rs
@@ -79,9 +79,10 @@ impl FunctionRuntime {
             )
             .try_build()
             .map_err(RuntimeError::FirepilotConfiguration)?;
-        let executor = FirecrackerExecutorBuilder::new()
+
+        let executor = FirecrackerExecutorBuilder::auto()
+            .map_err(RuntimeError::FirepilotConfiguration)?
             .with_chroot(DEFAULT_FIRECRACKER_WORKSPACE.to_string())
-            .with_exec_binary(self.function_config.firecracker_location.clone())
             .try_build()
             .map_err(RuntimeError::FirepilotConfiguration)?;
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #114 

## 📑 Description

- use firepilot ability to locate the firecracker binary instead of having to specify the binary location in arguments (see [docs](https://docs.rs/firepilot/latest/firepilot/builder/executor/struct.FirecrackerExecutorBuilder.html#method.auto))
- Document the ability to configure firecracker binary through environment variable in the project documentation

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code is documented
- [x] I provided unitary tests or procedure to test my code
- [x] My PR have a clear description of what my code is supposed to do

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->